### PR TITLE
fix zooming bug where drawLayer wasn’t called

### DIFF
--- a/ZoomingPDFViewer/TiledPDFView.swift
+++ b/ZoomingPDFViewer/TiledPDFView.swift
@@ -32,6 +32,10 @@ class TiledPDFView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
     
+    override func draw(_ rect: CGRect) {
+        // needs to be called even empty in order to call drawLayer func while zooming
+    }
+    
     // Draw the CGPDFPageRef into the layer at the correct scale.
     override func draw(_ layer: CALayer, in ctx: CGContext) {
         //print(pretty_function_string() + "myScale: \(myScale)")


### PR DESCRIPTION
fix zooming bug where drawLayer wasn’t called.

drawLayer needs a drawRect call (even if empty) in order to be validated and called.
Without drawRect, pinch to zoom displayed an empty white layer until closed.